### PR TITLE
Update store.getByIndex to use IDBIndex.getAll

### DIFF
--- a/dist/db.js
+++ b/dist/db.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const idb = typeof window === "undefined"
-    ? null
+    ? self && self.indexedDB
     : window.indexedDB ||
         window.webkitIndexedDB ||
         window.mozIndexedDB ||
@@ -24,8 +24,8 @@ class DB {
         this.idb.close();
     }
     delete() {
-        return promises_1.createPromise(arguments, (callback, resolve, reject) => {
-            promises_1.returnResult(null, idb.deleteDatabase(this.name), callback, resolve, reject);
+        return (0, promises_1.createPromise)(arguments, (callback, resolve, reject) => {
+            (0, promises_1.returnResult)(null, idb.deleteDatabase(this.name), callback, resolve, reject);
         });
     }
     onUpgradeNeeded(event) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,16 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.createTestingDB = exports.types = exports.IndexedDBPull = exports.Pull = exports.Push = void 0;
 const db_1 = require("./db");
 const push_1 = require("./push");
 exports.Push = push_1.default;
@@ -9,6 +20,7 @@ const indexeddb_pull_1 = require("./indexeddb-pull");
 exports.IndexedDBPull = indexeddb_pull_1.default;
 const types = require("./types");
 exports.types = types;
+__exportStar(require("./types"), exports);
 function createDB(name, options) {
     return new db_1.default(name, options);
 }

--- a/dist/promises.js
+++ b/dist/promises.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.createPromise = exports.returnResult = void 0;
 function returnResult(err, request, callback, resolve, reject, push) {
     if (err) {
         ;

--- a/dist/store.js
+++ b/dist/store.js
@@ -62,14 +62,14 @@ class Store {
         return this.mode(READ_ONLY, callback);
     }
     all(optionalCallback) {
-        return promises_1.createPromise(arguments, (callback, resolve, reject) => {
+        return (0, promises_1.createPromise)(arguments, (callback, resolve, reject) => {
             this.readOnly((error, ro) => {
-                promises_1.returnResult(error, ro.openCursor(), callback, resolve, reject);
+                (0, promises_1.returnResult)(error, ro.openCursor(), callback, resolve, reject);
             });
         });
     }
     add(doc, optionalCallback) {
-        return promises_1.createPromise(arguments, (callback, resolve, reject) => {
+        return (0, promises_1.createPromise)(arguments, (callback, resolve, reject) => {
             this._add(doc, callback, resolve, reject, id => {
                 this.db.push.publish({
                     action: "add",
@@ -81,27 +81,27 @@ class Store {
         });
     }
     get(key, optionalCallback) {
-        return promises_1.createPromise(arguments, (callback, resolve, reject) => {
+        return (0, promises_1.createPromise)(arguments, (callback, resolve, reject) => {
             this.readOnly((error, ro) => {
-                promises_1.returnResult(error, ro.get(key), callback, resolve, reject);
+                (0, promises_1.returnResult)(error, ro.get(key), callback, resolve, reject);
             });
         });
     }
     getByIndex(indexName, indexValue, optionalCallback) {
-        return promises_1.createPromise(arguments, (callback, resolve, reject) => {
+        return (0, promises_1.createPromise)(arguments, (callback, resolve, reject) => {
             this.readOnly((error, ro) => {
-                promises_1.returnResult(error, ro.index(indexName).get(indexValue), callback, resolve, reject);
+                (0, promises_1.returnResult)(error, ro.index(indexName).getAll(indexValue), callback, resolve, reject);
             });
         });
     }
     cursor(range, direction, callback) {
         this.readOnly((error, ro) => {
-            promises_1.returnResult(error, ro.openCursor(this.range(range), direction), callback);
+            (0, promises_1.returnResult)(error, ro.openCursor(this.range(range), direction), callback);
         });
     }
     indexCursor(name, range, direction, callback) {
         this.readOnly((error, ro) => {
-            promises_1.returnResult(error, ro.index(name).openCursor(this.range(range), direction), callback);
+            (0, promises_1.returnResult)(error, ro.index(name).openCursor(this.range(range), direction), callback);
         });
     }
     onPublish(errors) {
@@ -118,11 +118,11 @@ class Store {
             callback = directionOrCallback;
         }
         this.readOnly((error, ro) => {
-            promises_1.returnResult(error, ro.index(indexName).openCursor(range, direction), callback);
+            (0, promises_1.returnResult)(error, ro.index(indexName).openCursor(range, direction), callback);
         });
     }
     update(doc, optionalCallback) {
-        return promises_1.createPromise(arguments, (callback, resolve, reject) => {
+        return (0, promises_1.createPromise)(arguments, (callback, resolve, reject) => {
             this._update(doc, callback, resolve, reject, id => {
                 this.db.push.publish({
                     action: "update",
@@ -134,7 +134,7 @@ class Store {
         });
     }
     delete(id, callback) {
-        return promises_1.createPromise(arguments, (callback, resolve, reject) => {
+        return (0, promises_1.createPromise)(arguments, (callback, resolve, reject) => {
             this._delete(id, callback, resolve, reject, () => {
                 this.db.push.publish({
                     action: "delete",
@@ -145,9 +145,9 @@ class Store {
         });
     }
     count(optionalCallback) {
-        return promises_1.createPromise(arguments, (callback, resolve, reject) => {
+        return (0, promises_1.createPromise)(arguments, (callback, resolve, reject) => {
             this.readOnly((error, ro) => {
-                promises_1.returnResult(error, ro.count(), callback, resolve, reject);
+                (0, promises_1.returnResult)(error, ro.count(), callback, resolve, reject);
             });
         });
     }
@@ -167,7 +167,7 @@ class Store {
         return options;
     }
     testing(optionalDB) {
-        const db = optionalDB || index_1.createTestingDB();
+        const db = optionalDB || (0, index_1.createTestingDB)();
         return db.store(this.name, this.isSimpleStore
             ? null
             : {
@@ -179,19 +179,19 @@ class Store {
     }
     _add(doc, callback, resolve, reject, push) {
         this.readWrite((error, rw) => {
-            promises_1.returnResult(error, rw.add(doc), callback, resolve, reject, push);
+            (0, promises_1.returnResult)(error, rw.add(doc), callback, resolve, reject, push);
             this.onChange.publish();
         });
     }
     _delete(id, callback, resolve, reject, push) {
         this.readWrite((error, rw) => {
-            promises_1.returnResult(error, rw.delete(id), callback, resolve, reject, push);
+            (0, promises_1.returnResult)(error, rw.delete(id), callback, resolve, reject, push);
             this.onChange.publish();
         });
     }
     _update(doc, callback, resolve, reject, push) {
         this.readWrite((error, rw) => {
-            promises_1.returnResult(error, rw.put(doc), callback, resolve, reject, push);
+            (0, promises_1.returnResult)(error, rw.put(doc), callback, resolve, reject, push);
             this.onChange.publish();
         });
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -128,7 +128,7 @@ export default class Store implements types.IStore {
       this.readOnly((error, ro) => {
         returnResult(
           error,
-          ro.index(indexName).get(indexValue),
+          ro.index(indexName).getAll(indexValue),
           callback,
           resolve,
           reject


### PR DESCRIPTION
According to the documentation for `indexeddb`, calling `store.getByIndex` could return a document or an array of documents.

The current version calls `IDBIndex.get` instead of `IDBIndex.getAll`. This pull request patches this issue.

Please let me know if there is anything else I missed, but in testing this appears to be working correctly now.

Thank you for ther great library. The local/remote sync features are just what I neede while also making IDB easier to use! ❤️